### PR TITLE
fix: update dependencies lock file

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -163,7 +163,7 @@ wheels = [
 
 [[package]]
 name = "cli-mcp"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "typer" },


### PR DESCRIPTION
## Summary
- uv.lock 파일을 업데이트하여 버전 1.0.1을 반영

## Test plan
- [x] pre-commit hooks 통과
- [x] 모든 테스트 통과

🤖 Generated with [Claude Code](https://claude.ai/code)